### PR TITLE
Enable ?format=text in URL

### DIFF
--- a/lib/oxidized/web/webapp.rb
+++ b/lib/oxidized/web/webapp.rb
@@ -202,7 +202,7 @@ module Oxidized
       def out template=:default
         if @json or params[:format] == 'json'
           json @data
-        elsif template == :text
+        elsif template == :text or params[:format] == 'text'
           content_type :text
           @data
         else


### PR DESCRIPTION
Hopefully this is the right way to do it, same approach as json above.

As an example of where this is used:

http://127.0.0.1:8080/node/version/view?node=hostname&group=&oid=9b05cda60562b2bcaac569cb507ef31be1df09d1&date=2015-08-19%2012:33:02%20+0100&num=10&format=text

Then gives you plaintext output